### PR TITLE
Fixes an issue with image caching

### DIFF
--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -45,8 +45,10 @@ gulp.task('extras', function () {
 });
 
 gulp.task('clean', function (cb) {
-  rimraf('.tmp', function () {
-    rimraf('dist', cb);
+  return $.cache.clearAll(cb, function() {
+    return rimraf('.tmp', function () {
+      return rimraf('dist', cb);
+    });
   });
 });
 


### PR DESCRIPTION
After building several times, some users experience an error related to https://github.com/jgable/gulp-cache/issues/31. This seems to fix it.
